### PR TITLE
typos: Sagemath -> Sage / Comma without a space / Mathoverflow -> MathOverflow

### DIFF
--- a/H2020/CVs/William.Hart.tex
+++ b/H2020/CVs/William.Hart.tex
@@ -6,16 +6,16 @@ as well as the main author and maintainer of the BSDNT bignum library, the
 Nemo and ANTIC libraries and a contributor to various other software packages.
 
 Before coming to Kaiserslautern, held a prestigious five year Career
-Acceleration Fellowship ``Algorithms in Algebraic Number Theory'' at Warwick 
+Acceleration Fellowship ``Algorithms in Algebraic Number Theory'' at Warwick
 University in the UK. He has been involved in a number of high performance
-computing records, including computation of congruent numbers (subject to the 
+computing records, including computation of congruent numbers (subject to the
 BSD conjecture) up to a trillion ($10^{12}$).
 
 William is the main author of the FFT code for multiplication of large integers
 and polynomials in both MPIR and Flint, which are used extensively by the Sage,
 Singular and Macaulay 2 computer algebra systems.
 
-The main focus of William's research has been in algorithms for fast arithmetic,fast integer and polynomial factorisation and to algebraic number theory,
+The main focus of William's research has been in algorithms for fast arithmetic, fast integer and polynomial factorisation and to algebraic number theory,
 including computation of modular equations and class invariants.
 \end{participant}
 %%% Local Variables:

--- a/H2020/WorkPackages/SocialAspects.tex
+++ b/H2020/WorkPackages/SocialAspects.tex
@@ -13,8 +13,8 @@
     an appropriate place to put this idea.}
 
 The primary objective of this work package is to analyse the ``mutual crowdsourcing''
-phenomenon occurring in the framework of development and maintenance of an open-source 
-virtual research environment. 
+phenomenon occurring in the framework of development and maintenance of an open-source
+virtual research environment.
 We will focus on identifying the incentives for all
 participants of the system, that would encourage sustained development of the
 most important parts.  To this end, we will use ideas from the
@@ -30,17 +30,17 @@ by computations done by VREs, and ways to mitigate the issues arising there.
 
 \begin{wpdescription}
 Crowdsourcing is a recent phenomenon
-in software development in particular, but not only there. E.g. 
+in software development in particular, but not only there. E.g.
 crowdsourcing of mathematical ideas occurs in online
 mathematics communities, such as Math-overflow \cite{mathoverflow} and
-in Polymath Projects \cite{polymath}. 
+in Polymath Projects \cite{polymath}.
 ``Mutual crowdsourcing'' is the main driving force
-in developing and maintaining of any large-scale open-source 
-virtual research environment. 
+in developing and maintaining of any large-scale open-source
+virtual research environment.
 
 Open source projects tend to be fragile, in the community sense, and
 suffer from disagreements that ultimately result in forks and
-the resulting repetition of effort. We will analyse this in 
+the resulting repetition of effort. We will analyse this in
 a setup of cooperative game theory, and try to design
 a finely tuned systems of incentives and rewards for contribution, to increase
 the stability of the community and its useful output.
@@ -51,10 +51,10 @@ most important parts of the system.  To this end, we will use ideas from the
 burgeoning field of mechanism design \cite{AGTbook} and in
 particular on recent research on crowdsourcing in algorithmic mechanism design
 \cite{crowds}.  While doing so, we will apply outcomes to a case study
-system---Sagemath.
+system --- \Sage.
 We will apply preference and opinion aggregation techniques \cite{pref-aggr} to  develop
-a community prioritisation scheme for Sagemath bugs and features requests, which 
-are presently being maintained on the Sagemath TRAC server \cite{trac-sagemath}  and implement
+a community prioritisation scheme for \Sage bugs and features requests, which
+are presently being maintained on the \Sage TRAC server \cite{trac-sagemath}  and implement
 them as a TRAC \cite{Trac} add-on.
 
 As well, we will study various development models for an academic free software ecosystem,
@@ -63,7 +63,7 @@ designed and implemented,  and databases of experimental data and test cases bei
 created and expanded.
 Trusting results of computer
 computations is crucial for usability; channels for communicating bug reports
-and fixes need to be carefully analysed from social point of view. 
+and fixes need to be carefully analysed from social point of view.
 Commercial closed source computer algebra and other computational systems often
 fail to react to bug reports in a timely manner, and seemingly are falling into the
 short-sighted trap of hiding bugs from potential and current users \cite{misfort},
@@ -80,12 +80,12 @@ A game-theoretic analysis of this situation will be attempted.
 \end{task}
 
 \begin{task}[title=Survey and collection of needed data,id=datacollection]
-We will survey the data needed to assess development models of 
-large-scale academic open-source projects, 
+We will survey the data needed to assess development models of
+large-scale academic open-source projects,
 such that the probable correlation between the size of the atomic contribution
-vs. the speed of the contribution making it into the code, 
+vs. the speed of the contribution making it into the code,
 and collect appropriate statistical data. The latter will require non-trivial
-amount of programming work, even only for the test system, Sagemath.
+amount of programming work, even only for the test system, \Sage.
 \end{task}
 
 \begin{task}[title=Collective decision making in development,id=decisionmaking]
@@ -95,7 +95,7 @@ Whereas the latter might be good enough for simple bug fixing, for more elaborat
 often leads to delays etc.
 We would like to investigate an voting-driven approach, where the priorities are being
 voted on by the developer community, and possibly the people who completed tasks
-are incentivised in some form (e.g. by ``karma points'', as on Mathoverflow).
+are incentivised in some form (e.g. by ``karma points'', as on MathOverflow).
 \end{task}
 
 \begin{task}[title=OOMMF case study: Evaluation]

--- a/H2020/ambition.tex
+++ b/H2020/ambition.tex
@@ -43,7 +43,7 @@ acknowledged, but the separate groups developing the systems have
 individually, neither the time nor the expertise to develop it. There
 have been a number of interesting projects which have explored
 different aspects of what is needed: \TODO{SCIEnce, SageMathCloud,
-  MathOverflow, Polymath, SAGE itself, SAGE notebooks, HPCGAP,
+  MathOverflow, Polymath, \Sage itself, \Sage notebooks, HPCGAP,
   recomputation} and we will build on the experiences, and where
 useful the software, of all of these.
 
@@ -111,11 +111,11 @@ unique challenges to the realisation of this ambition.
 Another source of unique challenges for this project is the need to
 interact with several large and diverse ecosystems of software
 developers. For instance the \GAP\ package development community, the
-SAGE development community, the wider Python community, the developers
+\Sage development community, the wider Python community, the developers
 of key open-source libraries on which we rely and so on.
 
 These communities exist in a delicate balance between collaboration
-and competition. For instance the SCIEnce project and SAGE were
+and competition. For instance the SCIEnce project and \Sage were
 simultaneously exploring two different approaches to linking
 open-source mathematical software. Many technical developments (better
 IO handling in \GAP, for instance) could usefully be shared, and at

--- a/H2020/proposal.tex
+++ b/H2020/proposal.tex
@@ -243,7 +243,7 @@ The concrete objectives of \TheProject are:
 Computational techniques have become a core asset for research in pure
   mathematics and its applications in the last decades. Mathematics
   communities have come together to develop powerful computational
-  tools, such as GAP, \PariGP, SAGE or Singular, and valuable on-line
+  tools, such as GAP, \PariGP, \Sage or Singular, and valuable on-line
   services such as the Encyclopedia of Integer Sequences and the ATLAS
   of Group Representations. \TODO{cite} In building these systems, 
   mathematicians have gained strong
@@ -252,7 +252,7 @@ Computational techniques have become a core asset for research in pure
 
 A number of approaches to linking these resources have been developed,
 such as the SCSCP protocol from the Framework 6 SCIEnce project, and
-the incorporation of a variety of free software tools in the SAGE
+the incorporation of a variety of free software tools in the \Sage 
 system, but the overall model is still that of a single mathematician
 running programs or interacting with a ``notebook''
 page. The software provides little or no support for other aspects of


### PR DESCRIPTION
"Sagemath" is nice, but officially and for sake of consistency it's still "Sage". Sorry for the whitespace cleanup, that was unintentionally :confused: 